### PR TITLE
Feature - Using twitter media warnings (blurring) on uploaded medias

### DIFF
--- a/src/v2/common/enums/submission-rating.enum.ts
+++ b/src/v2/common/enums/submission-rating.enum.ts
@@ -8,7 +8,7 @@ export enum ESubmissionRating {
 
 export namespace ESubmissionRating_Utils {
   /**
-   * Get matching ESubmissionRating from string
+   * Get matching ESubmissionRating of given string (PB rating keys)
    * @param srVal String value to convert
    * @returns Matching ESubmissionRating
    * @throws RangeError when srVal is an invalid rating key

--- a/src/v2/common/enums/submission-rating.enum.ts
+++ b/src/v2/common/enums/submission-rating.enum.ts
@@ -1,0 +1,25 @@
+// Copied from PB+ src (commons/src/enums/submission-rating.enum.ts)
+export enum ESubmissionRating { 
+  GENERAL = 'general',
+  MATURE = 'mature',
+  ADULT = 'adult',
+  EXTREME = 'extreme'
+}
+
+export namespace ESubmissionRating_Utils {
+  /**
+   * Get matching ESubmissionRating from string
+   * @param srVal String value to convert
+   * @returns Matching ESubmissionRating
+   * @throws RangeError when srVal is an invalid rating key
+   */
+  export function fromStringValue(srVal: string): ESubmissionRating | never {
+    const srIdx = Object
+      .values(ESubmissionRating)
+      .indexOf(srVal as ESubmissionRating);
+    
+    if(srIdx == -1) throw new RangeError(`Unknown submission rating: ${srVal}`)
+
+    return ESubmissionRating[Object.keys(ESubmissionRating)[srIdx]]
+  }
+}

--- a/src/v2/twitter/enums/twitter-sensitive-media-warnings.enum.ts
+++ b/src/v2/twitter/enums/twitter-sensitive-media-warnings.enum.ts
@@ -1,0 +1,42 @@
+import {ESubmissionRating, ESubmissionRating_Utils} from "../../common/enums/submission-rating.enum"
+
+// Twitter's warning tags
+export enum ESensitiveMediaWarnings {
+	OTHER = "other",
+	GRAPHIC_VIOLENCE = "graphic_violence",
+	ADULT_CONTENT = "adult_content"
+}
+
+export namespace ESensitiveMediaWarnings_Utils {
+	/**
+	 * Get matching ESensitiveMediaWarnings of given ESubmissionRating
+	 * @param rating PB rating to convert to Twitter's warning tag
+	 * @returns Matching ESensitiveMediaWarnings (Twitter warning tags) or
+	 * undefined if none
+	 */
+	export function getSMWFromRating(
+		rating: ESubmissionRating
+	): ESensitiveMediaWarnings {
+		switch(rating) {
+			case ESubmissionRating.ADULT:
+				return ESensitiveMediaWarnings.ADULT_CONTENT;
+			case ESubmissionRating.EXTREME:
+				return ESensitiveMediaWarnings.OTHER;
+			default:
+				return;
+		}
+	}
+
+	/**
+	 * Get matching ESensitiveMediaWarnings of given string (PB rating keys)
+	 * @param strVal Value to convert
+	 * @returns Matching ESensitiveMediaWarnings (Twitter warning tags) or
+	 * undefined if none
+	 * @throws RangeError when strVal is an invalid rating key
+	 */
+	export function fromPBRatingStringValue(
+		strVal: string
+	): ESensitiveMediaWarnings {
+		return getSMWFromRating(ESubmissionRating_Utils.fromStringValue(strVal));
+	}
+}

--- a/src/v2/twitter/enums/twitter-sensitive-media-warnings.enum.ts
+++ b/src/v2/twitter/enums/twitter-sensitive-media-warnings.enum.ts
@@ -18,10 +18,12 @@ export namespace ESensitiveMediaWarnings_Utils {
 		rating: ESubmissionRating
 	): ESensitiveMediaWarnings {
 		switch(rating) {
+			case ESubmissionRating.MATURE:
+				return ESensitiveMediaWarnings.OTHER;
 			case ESubmissionRating.ADULT:
 				return ESensitiveMediaWarnings.ADULT_CONTENT;
 			case ESubmissionRating.EXTREME:
-				return ESensitiveMediaWarnings.OTHER;
+				return ESensitiveMediaWarnings.GRAPHIC_VIOLENCE;
 			default:
 				return;
 		}

--- a/src/v2/twitter/interfaces/twitter-media-metadata-body.interface.ts
+++ b/src/v2/twitter/interfaces/twitter-media-metadata-body.interface.ts
@@ -1,0 +1,10 @@
+import {
+    ESensitiveMediaWarnings
+} from '../enums/twitter-sensitive-media-warnings.enum';
+
+// An undocumented part of Twitter's 1.1 API, yaaaay
+export interface ImediaMetadataBody {
+    alt_text?: {text: string}
+    media_id: string
+    sensitive_media_warning?: [ESensitiveMediaWarnings]
+}


### PR DESCRIPTION
## Implementing the use of Twitter media Metadata warnings (blurring).

Part of the required API call (`POST media/metadata/create`) is [undocumented](https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-metadata-create). 
See the following enum & interface for more info (reversed API calls using Twitter web UI):

- `src/v2/twitter/enums/twitter-sensitive-media-warnings.enum.ts`
- `src/v2/twitter/interfaces/twitter-media-metadata-body.interface.ts`

Only worked on PB API v2, v1 is untouched.